### PR TITLE
[FIX] stock_full_location_reservation: Don't return unmerged moves

### DIFF
--- a/stock_full_location_reservation/models/stock_move.py
+++ b/stock_full_location_reservation/models/stock_move.py
@@ -79,11 +79,16 @@ class StockMove(models.Model):
             self._do_unreserve()
             # Don't merge at confirm
             new_move._action_confirm(merge=False)
-            new_move = (
+            merged_move = (
                 (new_move | self)
                 .with_context(skip_undo_full_location_reservation=True)
                 ._merge_moves(merge_into=self)
             )
+            # If the concerned product is not the one of the original move,
+            # it hasn't been merged.
+            if len(merged_move) > 1:
+                return new_move
+            return merged_move
         return new_move
 
     def _full_location_reservation(self, package_only=None):

--- a/stock_full_location_reservation/models/stock_move.py
+++ b/stock_full_location_reservation/models/stock_move.py
@@ -72,6 +72,7 @@ class StockMove(models.Model):
                 product, qty, location, package
             )
         )
+        self.ensure_one()
         if self.picking_type_id.merge_move_for_full_location_reservation:
             # To be able to be merged, the new move should use the same source location as
             # the original one.

--- a/stock_full_location_reservation/models/stock_move_line.py
+++ b/stock_full_location_reservation/models/stock_move_line.py
@@ -45,7 +45,10 @@ class StockMoveLine(models.Model):
     def _full_location_reservation(self, package_only=None):
         reservable_qties = self._get_full_location_reservable_qties(package_only)
         moves_to_assign_ids = []
-        for line in self.exists():  # Move line should have been deleted
+        for line in self.exists():
+            # Move line should have been deleted during a move merge
+            if not line.exists():
+                continue
             # Copy location and package as move line could be deleted if merge occurs
             location = line.location_id
             package = line.package_id

--- a/stock_full_location_reservation/models/stock_move_line.py
+++ b/stock_full_location_reservation/models/stock_move_line.py
@@ -52,9 +52,11 @@ class StockMoveLine(models.Model):
             qties = reservable_qties.get(location, {}).get(package, {})
             if not qties:
                 continue
+            # Save the move as line should have been deleted after moves merge
+            move = line.move_id
             for product, qty in qties.items():
                 moves_to_assign_ids.append(
-                    line.move_id._full_location_reservation_create_move(
+                    move._full_location_reservation_create_move(
                         product, qty, location, package
                     ).id
                 )


### PR DESCRIPTION
If the product in the new move we want to merge is not the same as the product in the original move, the _merge_moves() function returns a recordset with both moves. So, return the new move only in that case.