### PR TITLE
[16.0][IMP] stock_full_location_reservation: Allow to not unreserve moves

### DIFF
--- a/stock_full_location_reservation/tests/common.py
+++ b/stock_full_location_reservation/tests/common.py
@@ -16,6 +16,12 @@ class TestStockFullLocationReservationCommon(TestStockCommon):
         cls.location_rack_child = cls.location.create(
             {"name": "Rack child", "location_id": cls.location_rack.id}
         )
+        cls.location_rack_child_2 = cls.location.create(
+            {"name": "Rack child 2", "location_id": cls.location_rack.id}
+        )
+        cls.location_rack_child_3 = cls.location.create(
+            {"name": "Rack child 3", "location_id": cls.location_rack.id}
+        )
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
 
     def _create_quant(self, product, location, qty, package=None):

--- a/stock_full_location_reservation/tests/test_full_location_reservation.py
+++ b/stock_full_location_reservation/tests/test_full_location_reservation.py
@@ -51,6 +51,73 @@ class TestFullLocationReservation(TestStockFullLocationReservationCommon):
         self._check_move_line_len(picking, 1)
         self._check_move_line_len(picking, 0, self._filter_func)
 
+    def test_multi_lines_per_move(self):
+        """
+        We create :
+
+            - Quantity of 10 on Rack of Product A
+            - Quantity of 10 on Rack 2 of Product A
+            - Quantity of 10 on Rack 3 of Product A
+
+        We create a picking of 30 from parent Rack, all quantities should
+        be reserved.
+
+        Then, we update the Rack to 60 and we launch the full reservation
+        on move 1.
+
+        The moves lines should remains, the reserved total quantity should
+        be 80 when the original demand should remain.
+
+        """
+        self.picking_type.merge_move_for_full_location_reservation = True
+        self._create_quants(
+            [
+                (self.productA, self.location_rack_child, 10.0),
+                (self.productA, self.location_rack_child_2, 10.0),
+                (self.productA, self.location_rack_child_3, 10.0),
+                (self.productB, self.location_rack_child, 15.0),
+            ]
+        )
+
+        picking = self._create_picking(
+            self.location_rack,
+            self.customer_location,
+            self.picking_type,
+            [[self.productA, 30]],
+        )
+        picking.action_confirm()
+        picking.action_assign()
+        self.assertEqual(1, len(picking.move_ids))
+        move_line_ids = picking.move_line_ids
+        self.assertEqual(3, len(picking.move_line_ids))
+
+        self._create_quants(
+            [
+                (self.productA, self.location_rack_child, 50.0),
+            ]
+        )
+
+        self.assertEqual(
+            60.0,
+            self.productA.with_context(
+                location=self.location_rack_child.id
+            ).qty_available,
+        )
+
+        picking.move_line_ids[0]._full_location_reservation()
+
+        self.assertEqual(3, len(picking.move_line_ids))
+
+        self.assertEqual(
+            move_line_ids,
+            picking.move_line_ids,
+        )
+        self.assertEqual(picking.move_line_ids[0].reserved_uom_qty, 60.0)
+
+        # The original demand stays at 30.0
+        self.assertEqual(picking.move_ids.product_uom_qty, 30.0)
+        self.assertEqual(picking.move_ids.reserved_availability, 80.0)
+
     def test_multiple_pickings(self):
         picking = self._create_picking(
             self.location_rack,
@@ -141,5 +208,6 @@ class TestFullLocationReservation(TestStockFullLocationReservationCommon):
         picking.do_full_location_reservation()
 
         self._check_move_line_len(picking, 1)
-        self.assertEqual(10.0, picking.move_ids.product_uom_qty)
+        # The original demand remains the same
+        self.assertEqual(5.0, picking.move_ids.product_uom_qty)
         self.assertEqual(10.0, picking.move_ids.reserved_availability)


### PR DESCRIPTION
Use the standard mechanism to update the reserved quantity instead of recreating a new move (and move lines).

@jbaudoux